### PR TITLE
Ability to run standalone UI server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp
 /db/*
 /old-play-framework/db/*
 /.vertx
+/src/main/resources/webroot/node_modules

--- a/src/main/resources/webroot/app/app.js
+++ b/src/main/resources/webroot/app/app.js
@@ -5,9 +5,13 @@
 (function() {
     'use strict';
 
-    angular.module('dave', [
+    var dave = angular.module('dave', [
         'ngRoute',
         'angular.morris',
         'googlechart'
     ]);
+
+    dave.constant('hostConfig', {
+        restURL: '/api/v1.0' // 'http(s)://someUrl:port/path'
+    });
 })();

--- a/src/main/resources/webroot/app/app.js
+++ b/src/main/resources/webroot/app/app.js
@@ -11,6 +11,10 @@
         'googlechart'
     ]);
 
+    dave.config(['$httpProvider', function($httpProvider) {
+        $httpProvider.defaults.withCredentials = true;
+    }]);
+
     dave.constant('hostConfig', {
         restURL: '/api/v1.0' // 'http(s)://someUrl:port/path'
     });

--- a/src/main/resources/webroot/app/login/login.controller.js
+++ b/src/main/resources/webroot/app/login/login.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('LoginController', LoginController);
 
-    function LoginController($scope, $http, $interval, $rootScope, $location) {
+    function LoginController($scope, $http, $interval, $rootScope, $location, hostConfig) {
         $rootScope.authStatus = false;
         $rootScope.authUsername = "";
 
@@ -19,9 +19,9 @@
         vm.logout = logout;
 
         var url = {
-            "status": '/api/v1.0/user/loginStatus',
-            "login": '/api/v1.0/user/login',
-            "logout": '/api/v1.0/user/logout'
+            "status": hostConfig.restURL + '/user/loginStatus',
+            "login": hostConfig.restURL + '/user/login',
+            "logout": hostConfig.restURL + '/user/logout'
         };
 
         checkAuth();

--- a/src/main/resources/webroot/app/margin-components/margin-component-history.controller.js
+++ b/src/main/resources/webroot/app/margin-components/margin-component-history.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('MarginComponentHistoryController', MarginComponentHistoryController);
 
-    function MarginComponentHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function MarginComponentHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseHistoryController.call(this, $scope, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -50,7 +50,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/mc/history/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.ccy;
+            return hostConfig.restURL + '/mc/history/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.ccy;
         }
     };
 })();

--- a/src/main/resources/webroot/app/margin-components/margin-component-latest-account-aggregation.controller.js
+++ b/src/main/resources/webroot/app/margin-components/margin-component-latest-account-aggregation.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('MarginComponentLatestAccountAggregationController', MarginComponentLatestAccountAggregationController);
 
-    function MarginComponentLatestAccountAggregationController($scope, $http, $interval, $filter, sortRecordsService) {
+    function MarginComponentLatestAccountAggregationController($scope, $http, $interval, $filter, sortRecordsService, hostConfig) {
         var vm = this;
         vm.defaultOrdering = ["clearer", "member", "account"];
         vm.ordering = vm.defaultOrdering;
@@ -97,7 +97,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/mc/latest/';
+            return hostConfig.restURL + '/mc/latest/';
         }
 
         $scope.$on("$destroy", function() {

--- a/src/main/resources/webroot/app/margin-components/margin-component-latest.controller.js
+++ b/src/main/resources/webroot/app/margin-components/margin-component-latest.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('MarginComponentLatestController', MarginComponentLatestController);
 
-    function MarginComponentLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function MarginComponentLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseLatestController.call(this, $scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -35,7 +35,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/mc/latest/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.ccy;
+            return hostConfig.restURL + '/mc/latest/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.ccy;
         }
     };
 })();

--- a/src/main/resources/webroot/app/margin-components/margin-component-treemap.controller.js
+++ b/src/main/resources/webroot/app/margin-components/margin-component-treemap.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('MarginComponentTreemapController', MarginComponentTreemapController);
 
-    function MarginComponentTreemapController($scope, $http, $interval, $location) {
+    function MarginComponentTreemapController($scope, $http, $interval, $location, hostConfig) {
         var vm = this;
         vm.initialLoad= true;
         vm.errorMessage = "";
@@ -15,7 +15,7 @@
         vm.selectHandler = selectHandler;
 
         var refresh = $interval(loadData, 60000);
-        var restQueryUrl = '/api/v1.0/mc/latest/';
+        var restQueryUrl = hostConfig.restURL + '/mc/latest/';
         var clearer;
 
         loadData();

--- a/src/main/resources/webroot/app/margin-shortfall-surplus/margin-shortfall-surplus-history.controller.js
+++ b/src/main/resources/webroot/app/margin-shortfall-surplus/margin-shortfall-surplus-history.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('MarginShortfallSurplusHistoryController', MarginShortfallSurplusHistoryController);
 
-    function MarginShortfallSurplusHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function MarginShortfallSurplusHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseHistoryController.call(this, $scope, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -38,7 +38,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/mss/history/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.clearingCcy + '/' + vm.route.ccy;
+            return hostConfig.restURL + '/mss/history/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.clearingCcy + '/' + vm.route.ccy;
         }
     };
 })();

--- a/src/main/resources/webroot/app/margin-shortfall-surplus/margin-shortfall-surplus-latest-summary.controller.js
+++ b/src/main/resources/webroot/app/margin-shortfall-surplus/margin-shortfall-surplus-latest-summary.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('MarginShortfallSurplusLatestSummaryController', MarginShortfallSurplusLatestSummaryController);
 
-    function MarginShortfallSurplusLatestSummaryController($scope, $http, $interval) {
+    function MarginShortfallSurplusLatestSummaryController($scope, $http, $interval, hostConfig) {
         var vm = this;
         vm.initialLoad= true;
         vm.errorMessage = "";
@@ -57,7 +57,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/mss/latest/';
+            return hostConfig.restURL + '/mss/latest/';
         }
 
         $scope.$on("$destroy", function() {

--- a/src/main/resources/webroot/app/margin-shortfall-surplus/margin-shortfall-surplus-latest.controller.js
+++ b/src/main/resources/webroot/app/margin-shortfall-surplus/margin-shortfall-surplus-latest.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('MarginShortfallSurplusLatestController', MarginShortfallSurplusLatestController);
 
-    function MarginShortfallSurplusLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function MarginShortfallSurplusLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseLatestController.call(this, $scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -33,7 +33,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/mss/latest/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.clearingCcy;
+            return hostConfig.restURL + '/mss/latest/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.clearingCcy;
         }
     };
 })();

--- a/src/main/resources/webroot/app/position-reports/position-report-bubblechart.controller.js
+++ b/src/main/resources/webroot/app/position-reports/position-report-bubblechart.controller.js
@@ -8,7 +8,7 @@
 
     angular.module('dave').controller('PositionReportBubbleChartController', PositionReportBubbleChartController);
 
-    function PositionReportBubbleChartController($scope, $http, $interval, $filter) {
+    function PositionReportBubbleChartController($scope, $http, $interval, $filter, hostConfig) {
         var vm = this;
         vm.initialLoad= true;
         vm.errorMessage = "";
@@ -18,7 +18,7 @@
         vm.topRecordsCount = "20";
 
         var refresh = $interval(loadData, 60000);
-        var restQueryUrl = '/api/v1.0/pr/latest/';
+        var restQueryUrl = hostConfig.restURL + '/pr/latest/';
         var bubblesMap = new Map();
         var compVarPositiveLegend = "Positive";
         var compVarNegativeLegend = "Negative";

--- a/src/main/resources/webroot/app/position-reports/position-report-history.controller.js
+++ b/src/main/resources/webroot/app/position-reports/position-report-history.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('PositionReportHistoryController', PositionReportHistoryController);
 
-    function PositionReportHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function PositionReportHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseHistoryController.call(this, $scope, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -60,7 +60,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/pr/history/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.symbol + '/' + vm.route.putCall + '/' + vm.route.strikePrice + '/' + vm.route.optAttribute + "/" + vm.route.maturityMonthYear;
+            return hostConfig.restURL + '/pr/history/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.symbol + '/' + vm.route.putCall + '/' + vm.route.strikePrice + '/' + vm.route.optAttribute + "/" + vm.route.maturityMonthYear;
         }
     };
 })();

--- a/src/main/resources/webroot/app/position-reports/position-report-latest.controller.js
+++ b/src/main/resources/webroot/app/position-reports/position-report-latest.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('PositionReportLatestController', PositionReportLatestController);
 
-    function PositionReportLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function PositionReportLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseLatestController.call(this, $scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -43,7 +43,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/pr/latest/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.symbol + '/' + vm.route.putCall + '/' + vm.route.strikePrice + '/' + vm.route.optAttribute + "/" + vm.route.maturityMonthYear;
+            return hostConfig.restURL + '/pr/latest/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.class + '/' + vm.route.symbol + '/' + vm.route.putCall + '/' + vm.route.strikePrice + '/' + vm.route.optAttribute + "/" + vm.route.maturityMonthYear;
         }
     };
 })();

--- a/src/main/resources/webroot/app/risk-limits/risk-limit-history.controller.js
+++ b/src/main/resources/webroot/app/risk-limits/risk-limit-history.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('RiskLimitHistoryController', RiskLimitHistoryController);
 
-    function RiskLimitHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function RiskLimitHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseHistoryController.call(this, $scope, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -57,7 +57,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/rl/history/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.maintainer + '/' + vm.route.limitType;
+            return hostConfig.restURL + '/rl/history/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.maintainer + '/' + vm.route.limitType;
         }
     };
 })();

--- a/src/main/resources/webroot/app/risk-limits/risk-limit-latest.controller.js
+++ b/src/main/resources/webroot/app/risk-limits/risk-limit-latest.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('RiskLimitLatestController', RiskLimitLatestController);
 
-    function RiskLimitLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function RiskLimitLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseLatestController.call(this, $scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -43,7 +43,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/rl/latest/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.maintainer + '/' + vm.route.limitType;
+            return hostConfig.restURL + '/rl/latest/' + vm.route.clearer + '/' + vm.route.member + '/' + vm.route.maintainer + '/' + vm.route.limitType;
         }
     };
 })();

--- a/src/main/resources/webroot/app/total-margin-requirement/total-margin-requirement-history.controller.js
+++ b/src/main/resources/webroot/app/total-margin-requirement/total-margin-requirement-history.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('TotalMarginRequirementHistoryController', TotalMarginRequirementHistoryController);
 
-    function TotalMarginRequirementHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function TotalMarginRequirementHistoryController($scope, $routeParams, $http, $interval, $filter, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseHistoryController.call(this, $scope, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -34,7 +34,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/tmr/history/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.ccy;
+            return hostConfig.restURL + '/tmr/history/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.ccy;
         }
     };
 })();

--- a/src/main/resources/webroot/app/total-margin-requirement/total-margin-requirement-latest.controller.js
+++ b/src/main/resources/webroot/app/total-margin-requirement/total-margin-requirement-latest.controller.js
@@ -7,7 +7,7 @@
 
     angular.module('dave').controller('TotalMarginRequirementLatestController', TotalMarginRequirementLatestController);
 
-    function TotalMarginRequirementLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService) {
+    function TotalMarginRequirementLatestController($scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService, hostConfig) {
         BaseLatestController.call(this, $scope, $routeParams, $http, $interval, sortRecordsService, recordCountService, updateViewWindowService, showExtraInfoService, downloadAsCsvService);
         var vm = this;
         vm.route = {
@@ -32,7 +32,7 @@
         }
 
         function getRestQueryUrl() {
-            return '/api/v1.0/tmr/latest/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.ccy;
+            return hostConfig.restURL + '/tmr/latest/' + vm.route.clearer + '/' + vm.route.pool + '/' + vm.route.member + '/' + vm.route.account + '/' + vm.route.ccy;
         }
     };
 })();

--- a/src/main/resources/webroot/app/total-margin-requirement/total-margin-requirement-treemap.controller.js
+++ b/src/main/resources/webroot/app/total-margin-requirement/total-margin-requirement-treemap.controller.js
@@ -7,14 +7,14 @@
 
     angular.module('dave').controller('TotalMarginRequirementTreemapController', TotalMarginRequirementTreemapController);
 
-    function TotalMarginRequirementTreemapController($scope, $http, $interval) {
+    function TotalMarginRequirementTreemapController($scope, $http, $interval, hostConfig) {
         var vm = this;
         vm.initialLoad= true;
         vm.errorMessage = "";
         vm.chartObject = {};
 
         var refresh = $interval(loadData, 60000);
-        var restQueryUrl = '/api/v1.0/tmr/latest/';
+        var restQueryUrl = hostConfig.restURL + '/tmr/latest/';
 
         loadData();
 

--- a/src/main/resources/webroot/app/trading-session-status.controller.js
+++ b/src/main/resources/webroot/app/trading-session-status.controller.js
@@ -7,11 +7,11 @@
 
     angular.module('dave').controller('TradingSessionStatusController', TradingSessionStatusController);
 
-    function TradingSessionStatusController($scope, $http, $interval, $rootScope) {
+    function TradingSessionStatusController($scope, $http, $interval, $rootScope, hostConfig) {
         var vm = this;
         vm.tss = null;
 
-        var url = '/api/v1.0/tss/latest';
+        var url = hostConfig.restURL + '/tss/latest';
         var refresh = null;
 
         getTradingSessionStatus()

--- a/src/main/resources/webroot/gruntfile.js
+++ b/src/main/resources/webroot/gruntfile.js
@@ -1,0 +1,46 @@
+module.exports = function (grunt) {
+    'use strict';
+
+    var fallback = require('connect-history-api-fallback'),
+        log = require('connect-logger'),
+        cssPattern = ['app/**/*.css', 'vendor/**/*.css'],
+        htmlPattern = ['app/**/*.html', 'vendor/**/*.html', 'index.html'],
+        jsPattern = ['app/**/*.js', 'vendor/**/*.js'];
+
+    grunt.initConfig({
+
+        browserSync: {
+            dev: {
+                bsFiles: {
+                    src: cssPattern.concat(htmlPattern).concat(jsPattern)
+                },
+                options: {
+                    injectChanges: false,
+                    ui: false,
+                    server: {
+                        baseDir: './',
+                        middleware: [
+                            log({format: '%date %status %method %url'}),
+                            fallback({
+                                index: '/index.html',
+                                htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'] // systemjs workaround
+                            })
+                        ]
+                    },
+                    browser: [
+                        'chrome',
+                        'google chrome' // For macOS
+                    ],
+                    watchTask: false
+                }
+            }
+        }
+    });
+
+    // Dev run tools
+    grunt.loadNpmTasks('grunt-browser-sync');
+
+
+    // register at least this one task
+    grunt.registerTask('default', ['browserSync']);
+};

--- a/src/main/resources/webroot/package.json
+++ b/src/main/resources/webroot/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "DAVe",
+    "version": "1.0.0",
+    "scripts": {
+        "start": "grunt"
+    },
+    "dependencies": {
+    },
+    "devDependencies": {
+        "grunt": "^1.0.1",
+        "grunt-browser-sync": "^2.2.0",
+        "connect-logger": "0.0.1",
+        "connect-history-api-fallback": "^1.3.0"
+    }
+}


### PR DESCRIPTION
Added new option to run a standalone server using BrowserSync.

## Installation

Install [npm](http://blog.npmjs.org/post/85484771375/how-to-install-npm) first.

Install Grunt CLI using `npm install -g grunt-cli`. Use `sudo` on Linux or Mac if necessary.

Then run `npm install` to download necessary packages.

## To run server
Run `npm start` or `grunt` to start the server/browser.